### PR TITLE
Added support for OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # awto-pi-lot [![NPM Version](https://img.shields.io/npm/v/awto-pi-lot)](https://www.npmjs.com/package/awto-pi-lot)
 
-awto-pi-lot is an extension for [pi-coding-agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) that adds support for [PPQ.ai](https://ppq.ai/) & [NanoGPT](https://nano-gpt.com/) providers.
+awto-pi-lot is an extension for [pi-coding-agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) and [opencode](https://opencode.ai) that adds support for [PPQ.ai](https://ppq.ai/) & [NanoGPT](https://nano-gpt.com/) providers.
 
 
 ## Info
@@ -9,6 +9,8 @@ To see the potential benefits of using accountless AI providers, see https://git
 
 
 ## Install/use
+
+### pi-coding-agent
 
 Install it with:
 
@@ -34,10 +36,15 @@ Or from git directly:
 pi --extension git:github.com/tarsgate/awto-pi-lot
 ```
 
+### OpenCode
+
+See https://opencode.ai/docs/plugins/#use-a-plugin.
 
 ## Setup/auth
 
-You can authenticate with an [auth.json](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md#auth-file) file to hook your key, e.g.:
+### pi-coding-agent
+
+You can authenticate with an [auth.json](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md#auth-file) file to hook your key, e.g.:
 
 ```
 {
@@ -48,7 +55,11 @@ You can authenticate with an [auth.json](https://github.com/earendil-works/pi/bl
 
 And place in `~/.pi/agent/auth.json`.
 
-Using env vars (PPQ_API_KEY, NANOGPT_API_KEY) is also supported but not recommended, because security tools like [skynot](https://github.com/tarsgate/skynot) or [pi-less-yolo](https://github.com/cjermain/pi-less-yolo) might not work well with env vars OOTB.
+Using env vars (PPQ_API_KEY, NANOGPT_API_KEY) is also supported but not recommended, because security tools like [skynot](https://github.com/tarsgate/skynot) or [pi-less-yolo](https://github.com/cjermain/pi-less-yolo) don't work with env vars OOTB.
+
+### OpenCode
+
+Use (PPQ_API_KEY, NANOGPT_API_KEY) environment variables. This only has to be specified one time, as OpenCode will remember the key.
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
-export { default } from "./src/awto-pi-lot.ts";
+export { default } from "./src/pi-plugin.ts";
+export { PpqPlugin } from "./src/opencode-plugin.ts";

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
 	},
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.79.9",
+		"@opencode-ai/plugin": "1.4.6",
 		"prettier": "2.8.3",
 		"@biomejs/biome": "2.3.5",
 		"@types/node": "22.10.5",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
 		"pay-as-you-go",
 		"autoclaw",
 		"bitcoin",
-		"lightning"
+		"lightning",
+		"opencode",
+		"opencode-plugin",
+		"plugin",
+		"extension"
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/tarsgate/awto-pi-lot#readme",

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -3,7 +3,13 @@ enum LogType {
     Error,
 }
 
-export class Logger {
+export interface ILogger {
+    log(...args: string[]): void;
+    error(...args: string[]): void;
+    flush(): Promise<void>;
+}
+
+export class Logger implements ILogger {
     private logs: Array<{ type: LogType; args: Array<string> }> = [];
 
     log(...args: string[]) {
@@ -14,7 +20,7 @@ export class Logger {
         this.logs.push({ type: LogType.Error, args });
     }
 
-    flush() {
+    async flush() {
         for (const entry of this.logs) {
             if (entry.type === LogType.Log) {
                 console.log(...entry.args);

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,27 @@
+enum LogType {
+    Log,
+    Error,
+}
+
+export class Logger {
+    private logs: Array<{ type: LogType; args: Array<string> }> = [];
+
+    log(...args: string[]) {
+        this.logs.push({ type: LogType.Log, args });
+    }
+
+    error(...args: string[]) {
+        this.logs.push({ type: LogType.Error, args });
+    }
+
+    flush() {
+        for (const entry of this.logs) {
+            if (entry.type === LogType.Log) {
+                console.log(...entry.args);
+            } else {
+                console.error(...entry.args);
+            }
+        }
+        this.logs = [];
+    }
+}

--- a/src/nano-gpt.ts
+++ b/src/nano-gpt.ts
@@ -73,7 +73,7 @@ function filterModels(
         // pi requires models to have tool support
         if (
             !model.id.startsWith(autoModelPrefix) &&
-            !model.capabilities["tool_calling"]
+            !model.capabilities.tool_calling
         ) {
             continue;
         }
@@ -81,7 +81,7 @@ function filterModels(
         models.push({
             id: model.id,
             name: model.id,
-            reasoning: model.capabilities["reasoning"],
+            reasoning: model.capabilities.reasoning,
             input: ["text"] as Array<"text" | "image">,
             cost: {
                 input: model.pricing.prompt,
@@ -141,7 +141,7 @@ export async function fetchNanoGptModels(
     return models;
 }
 
-export function registerNanoGptProvider(
+export function registerNanoGptProviderInPi(
     pi: ExtensionAPI,
     models: Array<ProviderModelConfig>,
     logger: Logger

--- a/src/nano-gpt.ts
+++ b/src/nano-gpt.ts
@@ -8,7 +8,7 @@ import {
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { Empty, Some, Nothing, type Option, OptionHelpers } from "fp-sdk";
-import type { Logger } from "./awto-pi-lot.js";
+import type { Logger } from "./logging.js";
 
 interface NanoGptPricing {
     prompt: number;

--- a/src/nano-gpt.ts
+++ b/src/nano-gpt.ts
@@ -5,21 +5,23 @@ import {
     getAgentDir,
     type ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
+import type { ProviderConfig } from "@opencode-ai/sdk";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { Empty, Some, Nothing, type Option, OptionHelpers } from "fp-sdk";
-import type { Logger } from "./logging.js";
+import { Empty, Some, None, Nothing, type Option, OptionHelpers } from "fp-sdk";
+import type { ILogger } from "./logging.js";
 
 interface NanoGptPricing {
-    prompt: number;
-    completion: number;
+    prompt?: number;
+    completion?: number;
     currency: string;
     unit: string;
 }
 
 interface NanoGptModel {
     id: string;
-    context_length: number;
+    name: string;
+    context_length?: number;
     max_output_tokens?: number;
     pricing: NanoGptPricing;
     capabilities: Record<string, boolean>;
@@ -27,12 +29,12 @@ interface NanoGptModel {
 
 const providerId = "nanogpt";
 export const providerName = "NanoGPT";
-const apiKeyEnvVarName = "NANOGPT_API_KEY";
+export const apiKeyEnvVarName = "NANOGPT_API_KEY";
 const nanoGptBaseUrl = "https://nano-gpt.com/api/v1";
 
 async function fetchModels(
     apiKey: Option<string>,
-    logger: Logger
+    logger: ILogger
 ): Promise<Array<NanoGptModel>> {
     try {
         logger.log(`Fetching models from ${providerName}...`);
@@ -62,9 +64,9 @@ async function fetchModels(
     }
 }
 
-function filterModels(
+function filterModelsForPi(
     apiModels: Array<NanoGptModel>,
-    logger: Logger
+    logger: ILogger
 ): Array<ProviderModelConfig> {
     const models: Array<ProviderModelConfig> = Empty.array();
 
@@ -80,7 +82,7 @@ function filterModels(
 
         models.push({
             id: model.id,
-            name: model.id,
+            name: model.name,
             reasoning: model.capabilities.reasoning,
             input: ["text"] as Array<"text" | "image">,
             cost: {
@@ -109,7 +111,7 @@ function filterModels(
     return models;
 }
 
-function getNanoGptApiKey(): Option<string> {
+export function getNanoGptApiKey(): Option<string> {
     const envKey = process.env[apiKeyEnvVarName];
     if (envKey) {
         return OptionHelpers.ofObj(envKey);
@@ -127,12 +129,12 @@ function getNanoGptApiKey(): Option<string> {
     return Nothing;
 }
 
-export async function fetchNanoGptModels(
-    logger: Logger
+export async function fetchNanoGptModelsForPi(
+    apiKey: Option<string>,
+    logger: ILogger
 ): Promise<Array<ProviderModelConfig>> {
-    const apiKey = getNanoGptApiKey();
     const apiModels = await fetchModels(apiKey, logger);
-    const models = filterModels(apiModels, logger);
+    const models = filterModelsForPi(apiModels, logger);
     if (models.length === 0) {
         logger.error(
             `ERROR: no models from ${providerName} could be fetched/configured`
@@ -144,7 +146,7 @@ export async function fetchNanoGptModels(
 export function registerNanoGptProviderInPi(
     pi: ExtensionAPI,
     models: Array<ProviderModelConfig>,
-    logger: Logger
+    logger: ILogger
 ) {
     if (models.length === 0) {
         logger.error(
@@ -162,5 +164,104 @@ export function registerNanoGptProviderInPi(
     });
     logger.log(
         `Successfully loaded ${models.length} models from ${providerName}\r\n`
+    );
+}
+
+function filterModelsForOpenCode(
+    apiModels: Array<NanoGptModel>
+): ProviderConfig["models"] {
+    const opencodeModels: ProviderConfig["models"] =
+        (Empty.object() as ProviderConfig["models"])!;
+
+    for (const model of apiModels) {
+        opencodeModels[model.id] = {
+            id: model.id,
+            name: model.name,
+            tool_call: model.capabilities.tool_calling,
+            reasoning: model.capabilities.reasoning,
+            modalities: {
+                input: ["text"],
+                output: ["text"],
+            },
+        };
+
+        const maybeMaxOutputTokens = OptionHelpers.ofObj(
+            model.max_output_tokens
+        );
+        const maybeContextLength = OptionHelpers.ofObj(model.context_length);
+        if (
+            maybeMaxOutputTokens instanceof Some &&
+            maybeContextLength instanceof Some
+        ) {
+            opencodeModels[model.id].limit = {
+                context: maybeContextLength.value,
+                output: maybeMaxOutputTokens.value,
+            };
+        }
+
+        const maybeInputCost = OptionHelpers.ofObj(model.pricing.prompt);
+        const maybeOutputCost = OptionHelpers.ofObj(model.pricing.completion);
+        if (maybeInputCost instanceof Some && maybeOutputCost instanceof Some) {
+            opencodeModels[model.id].cost = {
+                input: maybeInputCost.value,
+                output: maybeOutputCost.value,
+            };
+        }
+    }
+
+    return opencodeModels;
+}
+
+export async function fetchNanoGptModelsForOpenCode(
+    apiKey: Option<string>,
+    logger: ILogger
+): Promise<ProviderConfig["models"]> {
+    const apiModels = await fetchModels(apiKey, logger);
+    const models = filterModelsForOpenCode(apiModels);
+    const modelsCount = Object.entries(models!).length;
+    if (modelsCount === 0) {
+        logger.error(
+            `ERROR: no models from ${providerName} could be fetched/configured`
+        );
+    }
+    return models;
+}
+
+export function registerNanoGptProviderInOpenCode(
+    config: { provider?: { [key: string]: ProviderConfig } },
+    models: ProviderConfig["models"],
+    apiKey: string,
+    logger: ILogger
+) {
+    const modelsCount = Object.entries(models!).length;
+    if (modelsCount === 0) {
+        logger.error(
+            `WARNING: empty model list from ${providerName}, skipping provider registration`
+        );
+        return;
+    }
+
+    const maybeProvider = OptionHelpers.ofObj(config.provider);
+    let provider: Record<string, ProviderConfig>;
+    // Initialize the providers dictionary if it doesn't exist
+    if (maybeProvider instanceof None) {
+        config.provider = Empty.object() as Record<string, ProviderConfig>;
+        provider = config.provider;
+    } else {
+        provider = maybeProvider.value;
+    }
+
+    provider.nanogpt = {
+        npm: "@ai-sdk/openai-compatible",
+        name: providerName,
+        options: {
+            baseURL: nanoGptBaseUrl,
+            apiKey: apiKey,
+        },
+        models: models,
+    };
+
+    logger.log(
+        `Successfully loaded ${modelsCount} models from ${providerName}\r\n`
     );
 }

--- a/src/opencode-plugin.ts
+++ b/src/opencode-plugin.ts
@@ -8,6 +8,12 @@ import {
     fetchPpqModelsForOpenCode,
     providerName as ppqProviderName,
 } from "./ppq.js";
+import {
+    fetchNanoGptModelsForOpenCode,
+    apiKeyEnvVarName as nanoGptApiKeyEnvVarName,
+    registerNanoGptProviderInOpenCode,
+} from "./nano-gpt.js";
+import { OptionHelpers, Some } from "fp-sdk";
 import type { ILogger } from "./logging.js";
 
 type LogLevel = "debug" | "info" | "error" | "warn";
@@ -59,10 +65,29 @@ export const PpqPlugin: Plugin = async ({ client }) => {
                 `${packageJson.name} v${packageJson.version} initializing...\r\n`
             );
 
-            const models = await fetchPpqModelsForOpenCode(logger);
-            registerPpqProviderInOpenCode(config, models, logger);
+            const ppqModels = await fetchPpqModelsForOpenCode(logger);
+            registerPpqProviderInOpenCode(config, ppqModels, logger);
 
             logger.log(`Successfully loaded models for ${ppqProviderName}`);
+
+            const maybeNanoGptApiKey = OptionHelpers.ofObj(
+                process.env[nanoGptApiKeyEnvVarName]
+            );
+            const nanoGptModels = await fetchNanoGptModelsForOpenCode(
+                maybeNanoGptApiKey,
+                logger
+            );
+
+            const nanoGptProviderApiKey =
+                maybeNanoGptApiKey instanceof Some
+                    ? maybeNanoGptApiKey.value
+                    : nanoGptApiKeyEnvVarName;
+            await registerNanoGptProviderInOpenCode(
+                config,
+                nanoGptModels,
+                nanoGptProviderApiKey,
+                logger
+            );
 
             await logger.flush();
         },

--- a/src/opencode-plugin.ts
+++ b/src/opencode-plugin.ts
@@ -1,0 +1,70 @@
+import type { Plugin } from "@opencode-ai/plugin";
+import type { OpencodeClient } from "@opencode-ai/sdk";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
+import {
+    registerPpqProviderInOpenCode,
+    fetchPpqModelsForOpenCode,
+    providerName as ppqProviderName,
+} from "./ppq.js";
+import type { ILogger } from "./logging.js";
+
+type LogLevel = "debug" | "info" | "error" | "warn";
+
+type LogMessageBody = {
+    service: string;
+    level: LogLevel;
+    message: string;
+};
+
+class Logger implements ILogger {
+    private app: OpencodeClient["app"];
+    private logs: Array<LogMessageBody> = [];
+
+    constructor(app: OpencodeClient["app"]) {
+        this.app = app;
+    }
+
+    private writeLog(level: LogLevel, ...args: string[]) {
+        for (const arg of args) {
+            this.logs.push({
+                service: "awto-pi-lot",
+                level: level,
+                message: arg,
+            });
+        }
+    }
+
+    log(...args: string[]): void {
+        this.writeLog("info", ...args);
+    }
+    error(...args: string[]): void {
+        this.writeLog("error", ...args);
+    }
+    async flush() {
+        for (const messageBody of this.logs) {
+            await this.app.log({ body: messageBody });
+        }
+        this.logs = [];
+    }
+}
+
+export const PpqPlugin: Plugin = async ({ client }) => {
+    const logger = new Logger(client.app);
+
+    return {
+        async config(config) {
+            logger.log(
+                `${packageJson.name} v${packageJson.version} initializing...\r\n`
+            );
+
+            const models = await fetchPpqModelsForOpenCode(logger);
+            registerPpqProviderInOpenCode(config, models, logger);
+
+            logger.log(`Successfully loaded models for ${ppqProviderName}`);
+
+            await logger.flush();
+        },
+    };
+};

--- a/src/pi-plugin.ts
+++ b/src/pi-plugin.ts
@@ -3,29 +3,29 @@ const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
-    fetchPpqModels,
+    fetchPpqModelsForPi,
     providerName as ppqProviderName,
-    registerPpqProvider,
+    registerPpqProviderInPi,
 } from "./ppq.js";
 import {
     fetchNanoGptModels,
     providerName as nanoGptProviderName,
-    registerNanoGptProvider,
+    registerNanoGptProviderInPi,
 } from "./nano-gpt.js";
 import { Logger } from "./logging.js";
 
 async function setupPpqProvider(pi: ExtensionAPI) {
     const logger = new Logger();
-    const models = await fetchPpqModels(logger);
-    registerPpqProvider(pi, models, logger);
-    logger.flush();
+    const models = await fetchPpqModelsForPi(logger);
+    registerPpqProviderInPi(pi, models, logger);
+    await logger.flush();
 }
 
 async function setupNanoGptProvider(pi: ExtensionAPI) {
     const logger = new Logger();
     const models = await fetchNanoGptModels(logger);
-    registerNanoGptProvider(pi, models, logger);
-    logger.flush();
+    registerNanoGptProviderInPi(pi, models, logger);
+    await logger.flush();
 }
 
 export default async function (pi: ExtensionAPI) {

--- a/src/pi-plugin.ts
+++ b/src/pi-plugin.ts
@@ -8,7 +8,8 @@ import {
     registerPpqProviderInPi,
 } from "./ppq.js";
 import {
-    fetchNanoGptModels,
+    getNanoGptApiKey,
+    fetchNanoGptModelsForPi,
     providerName as nanoGptProviderName,
     registerNanoGptProviderInPi,
 } from "./nano-gpt.js";
@@ -23,7 +24,8 @@ async function setupPpqProvider(pi: ExtensionAPI) {
 
 async function setupNanoGptProvider(pi: ExtensionAPI) {
     const logger = new Logger();
-    const models = await fetchNanoGptModels(logger);
+    const apiKey = getNanoGptApiKey();
+    const models = await fetchNanoGptModelsForPi(apiKey, logger);
     registerNanoGptProviderInPi(pi, models, logger);
     await logger.flush();
 }

--- a/src/pi-plugin.ts
+++ b/src/pi-plugin.ts
@@ -12,34 +12,7 @@ import {
     providerName as nanoGptProviderName,
     registerNanoGptProvider,
 } from "./nano-gpt.js";
-
-enum LogType {
-    Log,
-    Error,
-}
-
-export class Logger {
-    private logs: Array<{ type: LogType; args: Array<string> }> = [];
-
-    log(...args: string[]) {
-        this.logs.push({ type: LogType.Log, args });
-    }
-
-    error(...args: string[]) {
-        this.logs.push({ type: LogType.Error, args });
-    }
-
-    flush() {
-        for (const entry of this.logs) {
-            if (entry.type === LogType.Log) {
-                console.log(...entry.args);
-            } else {
-                console.error(...entry.args);
-            }
-        }
-        this.logs = [];
-    }
-}
+import { Logger } from "./logging.js";
 
 async function setupPpqProvider(pi: ExtensionAPI) {
     const logger = new Logger();

--- a/src/ppq.ts
+++ b/src/ppq.ts
@@ -2,8 +2,9 @@ import type {
     ExtensionAPI,
     ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
-import { Empty, OptionHelpers, Some } from "fp-sdk";
-import type { Logger } from "./logging.js";
+import type { ProviderConfig } from "@opencode-ai/sdk";
+import { None, Nothing, type Option, OptionHelpers, Some, Empty } from "fp-sdk";
+import type { ILogger } from "./logging.js";
 
 interface PpqPricing {
     input_per_1M_tokens: number;
@@ -45,7 +46,7 @@ function isMetaModel(modelId: string): boolean {
     );
 }
 
-async function fetchModels(logger: Logger): Promise<Array<PpqModel>> {
+async function fetchModels(logger: ILogger): Promise<Array<PpqModel>> {
     try {
         logger.log(`Fetching models from ${providerName}...`);
         const response = await fetch(`${ppqApiBaseUrl}/v1/models`);
@@ -64,9 +65,9 @@ async function fetchModels(logger: Logger): Promise<Array<PpqModel>> {
     }
 }
 
-async function filterModels(
+async function filterModelsForPi(
     apiModels: Array<PpqModel>,
-    logger: Logger
+    logger: ILogger
 ): Promise<Array<ProviderModelConfig>> {
     try {
         const models: Array<ProviderModelConfig> = Empty.array();
@@ -142,11 +143,11 @@ async function filterModels(
     }
 }
 
-export async function fetchPpqModels(
-    logger: Logger
+export async function fetchPpqModelsForPi(
+    logger: ILogger
 ): Promise<Array<ProviderModelConfig>> {
     const apiModels = await fetchModels(logger);
-    const models = await filterModels(apiModels, logger);
+    const models = await filterModelsForPi(apiModels, logger);
     if (models.length === 0) {
         logger.error(
             `ERROR: no models from ${providerName} could be fetched/configured`
@@ -155,10 +156,10 @@ export async function fetchPpqModels(
     return models;
 }
 
-export function registerPpqProvider(
+export function registerPpqProviderInPi(
     pi: ExtensionAPI,
     models: Array<ProviderModelConfig>,
-    logger: Logger
+    logger: ILogger
 ) {
     if (models.length === 0) {
         logger.error(
@@ -175,5 +176,123 @@ export function registerPpqProvider(
     });
     logger.log(
         `Successfully loaded ${models.length} models from ${providerName}\r\n`
+    );
+}
+
+export async function filterPpqModelsForOpenCode(
+    apiModels: PpqModel[]
+): Promise<ProviderConfig["models"]> {
+    // PPQ API doesn't provide output limit, so use on from https://opencode.ai/docs/providers#example
+    const defaultOutputLimit = 65536;
+
+    function restrictToSupportedModalities(
+        modalities: Option<string[]>
+    ): ("text" | "image" | "audio" | "video" | "pdf")[] {
+        if (modalities instanceof None) {
+            return ["text"];
+        }
+        return modalities.value.filter((modality) => {
+            return (
+                modality === "text" ||
+                modality === "audio" ||
+                modality === "image" ||
+                modality === "video" ||
+                modality === "pdf"
+            );
+        });
+    }
+
+    const opencodeModels: ProviderConfig["models"] =
+        (Empty.object() as ProviderConfig["models"])!;
+    for (const model of apiModels) {
+        const maybeSupportedParameters = OptionHelpers.ofObj(
+            model.supported_parameters
+        );
+        const supportedParameters =
+            maybeSupportedParameters instanceof Some
+                ? maybeSupportedParameters.value
+                : [];
+        const maybeArchitecture = OptionHelpers.ofObj(model.architecture);
+        const inputModalities =
+            maybeArchitecture instanceof None
+                ? Nothing
+                : new Some(maybeArchitecture.value.input_modalities);
+        const outputModalities =
+            maybeArchitecture instanceof None
+                ? Nothing
+                : new Some(maybeArchitecture.value.output_modalities);
+
+        opencodeModels[model.id] = {
+            id: model.id,
+            name: model.name,
+            cost: {
+                input: model.pricing.input_per_1M_tokens,
+                output: model.pricing.output_per_1M_tokens,
+            },
+            limit: {
+                context: model.context_length,
+                output: defaultOutputLimit,
+            },
+            tool_call: supportedParameters.includes("tools"),
+            reasoning: supportedParameters.includes("reasoning"),
+            modalities: {
+                input: restrictToSupportedModalities(inputModalities),
+                output: restrictToSupportedModalities(outputModalities),
+            },
+        };
+    }
+
+    return opencodeModels;
+}
+
+export async function fetchPpqModelsForOpenCode(
+    logger: ILogger
+): Promise<ProviderConfig["models"]> {
+    const apiModels = await fetchModels(logger);
+    const models = await filterPpqModelsForOpenCode(apiModels);
+    if (Object.entries(models!).length === 0) {
+        logger.error(
+            `ERROR: no models from ${providerName} could be fetched/configured`
+        );
+    }
+    return models;
+}
+
+export function registerPpqProviderInOpenCode(
+    config: { provider?: { [key: string]: ProviderConfig } },
+    models: ProviderConfig["models"],
+    logger: ILogger
+) {
+    const modelsCount = Object.entries(models!).length;
+    if (modelsCount === 0) {
+        logger.error(
+            `WARNING: empty model list from ${providerName}, skipping provider registration`
+        );
+        return;
+    }
+
+    const maybeProvider = OptionHelpers.ofObj(config.provider);
+    let provider: Record<string, ProviderConfig>;
+    // Initialize the providers dictionary if it doesn't exist
+    if (maybeProvider instanceof None) {
+        config.provider = Empty.object() as Record<string, ProviderConfig>;
+        provider = config.provider;
+    } else {
+        provider = maybeProvider.value;
+    }
+
+    const apiKey = process.env.PPQ_API_KEY;
+    provider.ppq = {
+        npm: "@ai-sdk/openai-compatible",
+        name: "PPQ.ai",
+        options: {
+            baseURL: ppqApiBaseUrl,
+            apiKey: apiKey,
+        },
+        models: models,
+    };
+
+    logger.log(
+        `Successfully loaded ${modelsCount} models from ${providerName}\r\n`
     );
 }

--- a/src/ppq.ts
+++ b/src/ppq.ts
@@ -3,7 +3,7 @@ import type {
     ProviderModelConfig,
 } from "@earendil-works/pi-coding-agent";
 import { Empty, OptionHelpers, Some } from "fp-sdk";
-import type { Logger } from "./awto-pi-lot.js";
+import type { Logger } from "./logging.js";
 
 interface PpqPricing {
     input_per_1M_tokens: number;


### PR DESCRIPTION
The same package can be now used as an OpenCode plugin.

Due to both plugin functions being in the same file, opencode
tries to load both and fails on PPQ plugin, writing a log
entry about failing to load plugin, like this:

```
ERROR 2026-04-13T09:01:02 +962ms service=plugin path=file:///D:/Projects/work/opencode-ppq-plugin-test/.opencode/plugins/ppq.ts error=pi.registerProvider is not a function. (In 'pi.registerProvider("ppq", {
    baseUrl: ppqApiBaseUrl,
    api: "openai-completions",
    apiKey: "PPQ_API_KEY",
    models
  })', 'pi.registerProvider' is undefined) failed to load plugin
```

This error does not affect normal functioning of opencode and
only shows up in log.

Pi does not issue any warnings when loading the extension.
