### PR TITLE
CI: install awto-pi-lot from the specific commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,6 @@ jobs:
           URL="https://github.com/badlogic/pi-mono/releases/download/v${PI_VERSION}/pi-linux-x64.tar.gz"
           wget "$URL"
           tar -xzf "pi-linux-x64.tar.gz"
-          ./pi/pi install git:github.com/nblockchain/awto-pi-lot
+          ./pi/pi install git:github.com/${GITHUB_REPOSITORY}@${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.sha }}
           ./pi/pi --version
 


### PR DESCRIPTION
That spawns CI instead of installing from master.