### PR TITLE
CI: test extension loading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -105,3 +105,6 @@ jobs:
           ./pi/pi install git:github.com/${GITHUB_REPOSITORY}@${{ (github.event_name == 'pull_request' && github.event.pull_request.base.sha) || github.sha }}
           ./pi/pi --version
 
+      - name: Test extension loading
+        run: |
+          ./pi/pi --print "dummy prompt" | grep -q "API key"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,4 +107,4 @@ jobs:
 
       - name: Test extension loading
         run: |
-          ./pi/pi --print "dummy prompt" | grep -q "API key"
+          { set +o pipefail; ./pi/pi --print "dummy prompt" || true; } | grep -q "API key"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -107,4 +107,4 @@ jobs:
 
       - name: Test extension loading
         run: |
-          { set +o pipefail; ./pi/pi --print "dummy prompt" || true; } | grep -q "API key"
+          ./pi/pi --print "dummy prompt" > output.txt 2>&1 || true && grep -q "API key" output.txt


### PR DESCRIPTION
Test if extension loads successfully by running some example prompt. Since the API key is not given, output should contain error about missing API key. If it doesn't, it means that the extension failed with error before that.

Fixes https://github.com/nblockchain/awto-pi-lot/issues/12