### PR TITLE
Enable installation on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,8 @@
 	},
 	"scripts": {
 		"clean": "shx rm -rf dist",
-		"build": "npx tsc && cp README.md dist/",
-		"check": "npm install && npm run build && biome check --write --error-on-warnings .",
-		"prepare": "# can leave empty because Pi loads extensions with jiti"
+		"build": "npx tsc && shx cp README.md dist/",
+		"check": "npm install && npm run build && biome check --write --error-on-warnings ."
 	},
 	"keywords": [
 		"pi",


### PR DESCRIPTION
By removing "prepare" script that contains only bash comment, and replacing `cp` with `shx cp` in "build" script.

This enables installation and pre-commit hooks on Windows.

Fixes https://github.com/nblockchain/awto-pi-lot/issues/21