### PR TITLE
Sort 'auto' model as 2nd in the list after 'AutoClaw'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,9 +107,20 @@ async function filterPpqModels(
         }
 
         const defaultModelId = "autoclaw";
-        models.sort((a, b) =>
-            a.id === defaultModelId ? -1 : b.id === defaultModelId ? 1 : 0
-        );
+        const secondDefaultModelId = "auto";
+        models.sort((a, b) => {
+            const position = (id: string) => {
+                switch (id) {
+                    case defaultModelId:
+                        return 0;
+                    case secondDefaultModelId:
+                        return 1;
+                    default:
+                        return 2;
+                }
+            };
+            return position(a.id) - position(b.id);
+        });
 
         console.log(`Found ${models.length} compatible models from PPQ.ai`);
         return models;


### PR DESCRIPTION
This way, AutoClaw is still default (if you're interested in that, wait for PR7 to land), but at least this way the meta-model 'auto' is more discoverable.