### PR TITLE
package.json: move pi-coding-agent pckg to peerDependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check package versions
         run: |
           # Get versions from package.json
-          PI_CODING_AGENT_VERSION=$(node -p "require('./package.json').dependencies['@mariozechner/pi-coding-agent']")
+          PI_CODING_AGENT_VERSION=$(node -p "require('./package.json').peerDependencies['@mariozechner/pi-coding-agent']")
 
           if [ "$PI_VERSION" != "$PI_CODING_AGENT_VERSION" ]; then
             echo "ERROR: @mariozechner/pi-coding-agent version ($PI_CODING_AGENT_VERSION) does not match PI version ($PI_VERSION)"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
 		"url": "git+https://github.com/tarsgate/awto-pi-lot.git"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "0.67.68",
 		"fp-sdk": "^0.1.1"
+	},
+	"peerDependencies": {
+		"@mariozechner/pi-coding-agent": "0.67.68"
 	},
 	"devDependencies": {
 		"prettier": "2.8.3",


### PR DESCRIPTION
To make installing the extension faster because now that package doesn't have to be downloaded.