### PR TITLE
Move Pi's npm from deps to devDeps

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Check package versions
         run: |
           # Get versions from package.json
-          PI_CODING_AGENT_VERSION=$(node -p "require('./package.json').dependencies['@mariozechner/pi-coding-agent']")
+          PI_CODING_AGENT_VERSION=$(node -p "require('./package.json').devDependencies['@mariozechner/pi-coding-agent']")
 
           if [ "$PI_VERSION" != "$PI_CODING_AGENT_VERSION" ]; then
             echo "ERROR: @mariozechner/pi-coding-agent version ($PI_CODING_AGENT_VERSION) does not match PI version ($PI_VERSION)"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
 		"url": "git+https://github.com/tarsgate/awto-pi-lot.git"
 	},
 	"dependencies": {
-		"@mariozechner/pi-coding-agent": "0.70.2",
 		"fp-sdk": "^0.1.1"
 	},
 	"devDependencies": {
+		"@mariozechner/pi-coding-agent": "0.70.2",
 		"prettier": "2.8.3",
 		"@biomejs/biome": "2.3.5",
 		"@types/node": "^22.10.5",


### PR DESCRIPTION
This way the download&install of the extension is much faster.

Supersedes https://github.com/tarsgate/awto-pi-lot/pull/31