### PR TITLE
Rework Publish job to be prepared for GitHub's fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,20 +49,20 @@ jobs:
           echo "Package.json version: $PKG_VERSION"
 
           # Compare versions
-          #if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-          #  echo "ERROR: Git tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-          #  exit 1
-          #fi
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "ERROR: Git tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
 
-          #PKG_MINOR_PATCH="${PKG_VERSION#*.}"
-          #PI_MINOR_PATCH="${PI_VERSION#*.}"
+          PKG_MINOR_PATCH="${PKG_VERSION#*.}"
+          PI_MINOR_PATCH="${PI_VERSION#*.}"
 
-          #if [ "$PKG_MINOR_PATCH" != "$PI_MINOR_PATCH" ]; then
-          #    echo "Minor and patch components of package.json version ($PKG_VERSION) are different from corresponding components of pi version ($PI_VERSION)"
-          #    exit 1
-          #fi
+          if [ "$PKG_MINOR_PATCH" != "$PI_MINOR_PATCH" ]; then
+              echo "Minor and patch components of package.json version ($PKG_VERSION) are different from corresponding components of pi version ($PI_VERSION)"
+              exit 1
+          fi
 
-          #echo "✓ Versions match!"
+          echo "✓ Versions match!"
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -81,9 +81,6 @@ jobs:
 
       - name: Publish awto-pi-lot to npm
         run: |
-          # undo release mistake
-          npm unpublish awto-pi-lot@2.74.0
-
           npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,9 @@ on:
 jobs:
   bin-publish:
 
-    # can't use github.ref because of this bug: https://github.com/orgs/community/discussions/27124
-    if: ${{ github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v') }}
-    env:
-      HEAD_TAG: ${{ github.event.workflow_run.head_branch }}
+    # can use github.ref when triggered directly by tags, or head_branch for workflow_run triggers
+    # because of this bug: https://github.com/orgs/community/discussions/27124
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (startsWith(github.ref, 'refs/tags/v') || startsWith(github.event.workflow_run.head_branch, 'v')) }}
 
     runs-on: ubuntu-latest
 
@@ -26,11 +25,23 @@ jobs:
       - name: Load variables from .env file
         run: cat .env >> $GITHUB_ENV
 
+      - name: Determine tag version
+        env:
+          REF: ${{ github.ref }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [[ "$REF" == refs/tags/v* ]]; then
+            HEAD_TAG="$REF"
+          else
+            HEAD_TAG="$HEAD_BRANCH"
+          fi
+          TAG_VERSION="${HEAD_TAG#refs/tags/}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          echo "HEAD_TAG=$HEAD_TAG" >> "$GITHUB_ENV"
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+
       - name: Verify version matches tag
         run: |
-          # Extract tag version (remove 'v' prefix if present)
-          TAG_VERSION="${HEAD_TAG#v}"
-
           # Get version from package.json
           PKG_VERSION=$(node -p "require('./package.json').version")
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "awto-pi-lot",
-	"version": "2.73.99",
+	"version": "2.74.0",
 	"type": "module",
 	"description": "pi-coding-agent extension that adds PPQ.ai provider and their AutoClaw model",
 	"pi": {


### PR DESCRIPTION
If GitHub decides to fix the bug in the future again, without reverting the behaviour, we'll be ready for both cases this way.

This is related to these recent commits:
* 9ee9460f3dcc0173a4356aafda255693e7e8dec1
* b1297a3e068d9a9a4ac8b3b4744654ac92e0c49c
* e8cb198811f3a33aa647b9ac0a27459cd0470905