### PR TITLE
package.json: pin dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,17 +40,17 @@
 		"url": "git+https://github.com/tarsgate/awto-pi-lot.git"
 	},
 	"dependencies": {
-		"fp-sdk": "^0.1.2"
+		"fp-sdk": "0.1.2"
 	},
 	"devDependencies": {
 		"@earendil-works/pi-coding-agent": "0.75.5",
 		"prettier": "2.8.3",
 		"@biomejs/biome": "2.3.5",
-		"@types/node": "^22.10.5",
-		"husky": "^9.1.7",
-		"shx": "^0.4.0",
-		"tsx": "^4.20.3",
-		"typescript": "^5.9.2"
+		"@types/node": "22.10.5",
+		"husky": "9.1.7",
+		"shx": "0.4.0",
+		"tsx": "4.20.3",
+		"typescript": "5.9.2"
 	},
 	"engines": {
 		"node": ">=20.0.0"


### PR DESCRIPTION
I've been a long proponent of not updating deps for update sake, and even if I have refused to use dependabot for long time, this is not enough in the NPM ecosystem because deps can still be updated by your users due to this dreadful ^ character next to the version number of your dependency.

Now, in this climate of constant supply-chain attacks, finally decent devs from the industry are starting to speak up about this shit[1] and also taking action[2], so I'll follow suit.

[1] https://x.com/mitchellh/status/2057171518027887035
[2] https://github.com/earendil-works/pi/commit/2e02c74dcb9787e3feca7fad67082faed4a1b3cd